### PR TITLE
Fix preview flipped horizontally

### DIFF
--- a/tetris.ts
+++ b/tetris.ts
@@ -518,7 +518,7 @@ class Game{
         for(var n = 0; n < nextArray.length; n++){
           for(var i = 0; i < nextArray[n].length; i++){
             for(var j = 0; j < nextArray[n][i].length; j++){
-                if(nextArray[n][i][j] == 1){
+                if(nextArray[n][nextArray[n].length - 1 - i][j] == 1){
                   nextBlockChild[i].children[j].setAttribute("class", "block opened");
                 }else{
                   nextBlockChild[i].children[j].setAttribute("class", "block blank");


### PR DESCRIPTION
Hi. I had fun playing your game! I've found a little issue, it seems like blocks on the preview are flipped horizontally (mirrored), so we get S-blocks instead of expected Z-blocks, L-blocks instead of expected J-blocks, etc. Feel free to merge my fix for better user experience.